### PR TITLE
dataclasses for py 3.6

### DIFF
--- a/python/light-curve/Cargo.toml
+++ b/python/light-curve/Cargo.toml
@@ -43,5 +43,5 @@ features = ["extension-module"]
 
 [package.metadata.maturin]
 name = "light-curve"
-requires-dist = ["numpy", "scipy"]
+requires-dist = ["numpy", "scipy", "dataclasses ; python_version < \"3.7\""]
 classifier = ["Intended Audience :: Science/Research", "License :: OSI Approved :: MIT License", "Programming Language :: Python", "Programming Language :: Python :: 3 :: Only", "Programming Language :: Python :: 3.6", "Programming Language :: Python :: 3.7", "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9", "Programming Language :: Rust", "Topic :: Scientific/Engineering :: Astronomy"]


### PR DESCRIPTION
`dataclasses` package appeared in Python 3.7. We support Python 3.6+ (but #57), so we must install `dataclasses` backport for Python 3.6