### PR TITLE
Universal Extractor

### DIFF
--- a/.ci/Dockerfile.maturin
+++ b/.ci/Dockerfile.maturin
@@ -1,0 +1,6 @@
+FROM konstin2/maturin
+
+RUN yum install -y openssl-devel
+
+RUN python3 -m pip install -U pip
+RUN python3 -m pip install tox

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "cargo"
+    directory: "/light-curve-feature"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "cargo"
+    directory: "/light-curve-dmdt"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -6,12 +6,29 @@ on:
       - light-curve-python-v*
 
 jobs:
-  publish:
-    runs-on: ${{ matrix.os }}
+  publish-linux:
+    runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-10.15]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build docker image
+      run: docker build --no-cache --tag maturin -f .ci/Dockerfile.maturin .ci
+    - name: Build wheels for tests
+      run: docker run --rm -v $(realpath python/light-curve):/io maturin build --release -i python3.6 python3.7 python3.8 python3.9 --cargo-extra-args="--no-default-features --features mkl"
+    - name: Run Python tests
+      run: docker run --rm -v $(realpath python/light-curve):/io --entrypoint=/bin/bash maturin -c 'python3.6 -m pip install target/wheels/*cp36*.whl && python3.7 -m pip install target/wheels/*cp37*.whl && python3.8 -m pip install target/wheels/*cp38*.whl && python3.9 -m pip install target/wheels/*cp39*.whl && python3 -m tox -p --skip-pkg-install --sitepackages'
+    - name: Publish Linux light-curve
+      run: docker run --rm -v $(realpath python/light-curve):/io konstin2/maturin publish -i python3.6 python3.7 python3.8 python3.9 -u __token__ -p ${{ secrets.PYPI_TOKEN_LIGHT_CURVE }}
+    - name: Publish light-curve-python
+      run: |
+        python3 setup.py sdist
+        twine check --strict dist/*
+        twine upload dist/* -u __token__ -p ${{ secrets.PYPI_TOKEN }} --verbose
+      working-directory: python/light-curve-python
+
+
+  publish-macos:
+    runs-on: macos-10.15
 
     defaults:
       run:
@@ -43,11 +60,5 @@ jobs:
       run: pip install tox maturin twine
     - name: Run Python tests
       run: tox -p -q
-    - name: Publish Linux light-curve
-      if: ${{ matrix.os == 'ubuntu-20.04' }}
-      run: docker run --rm -v $(pwd):/io konstin2/maturin publish -i python3.6 python3.7 python3.8 python3.9 -u __token__ -p ${{ secrets.PYPI_TOKEN_LIGHT_CURVE }}
-    - name: Publish macOS light-curve
-      if: ${{ matrix.os != 'ubuntu-20.04' }}
+    - name: Publish macOS packages
       run: maturin publish --no-sdist -i python3.6 python3.7 python3.8 python3.9 -u __token__ -p ${{ secrets.PYPI_TOKEN_LIGHT_CURVE }}
-    - name: Publish light-curve-python
-      run: python3 setup.py sdist && twine check --strict dist/* && twine upload dist/* -u __token__ -p ${{ secrets.PYPI_TOKEN }} --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --workspace --all-targets --exclude light-curve-python
+        args: --workspace --all-targets --exclude python/light-curve
     - name: Build light-curve-feature gsl+fftw-source
       uses: actions-rs/cargo@v1
       with:
@@ -40,7 +40,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace --exclude light-curve-python
+        args: --workspace --exclude python/light-curve
     - name: Check formatting
       uses: actions-rs/cargo@v1
       with:
@@ -50,7 +50,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --workspace --exclude light-curve-python --all-targets -- -D warnings
+        args: --workspace --exclude python/light-curve --all-targets -- -D warnings
 
 
   python:
@@ -94,7 +94,7 @@ jobs:
     - name: Build package with dynamic FFTW
       run: maturin build --manylinux=off --cargo-extra-args="--no-default-features --features fftw-dynamic,nonlinear-fit"
     - name: Build package with dynamic MKL
-      run: maturin build --manylinux=off --cargo-extra-args="--no-default-features --features mkl-dynamic,nonlinear-fit"
+      run: maturin build --manylinux=off --cargo-extra-args="--no-default-features --features mkl,nonlinear-fit"
     - name: Check Rust formatting
       uses: actions-rs/cargo@v1
       with:
@@ -105,9 +105,20 @@ jobs:
       with:
         command: clippy
         args: --all-targets -- -D warnings
-    - name: Check Python formatting
-      run: black .
     - name: Run Python tests
       run: tox -p -q
     - name: Check Python formatting
       run: black --check --diff .
+
+
+  arm:
+
+    runs-on: [self-hosted, linux, ARM64]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: build all but python
+        run: cargo build --workspace --all-targets --exclude python/light-curve
+      - name: build python
+        run: maturin build
+        working-directory: python/light-curve

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --workspace --all-targets --exclude python/light-curve
+        args: --workspace --all-targets --exclude light-curve-python
     - name: Build light-curve-feature gsl+fftw-source
       uses: actions-rs/cargo@v1
       with:
@@ -42,7 +42,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace --exclude python/light-curve
+        args: --workspace --exclude light-curve-python
     - name: Check formatting
       uses: actions-rs/cargo@v1
       with:
@@ -52,7 +52,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --workspace --exclude python/light-curve --all-targets -- -D warnings
+        args: --workspace --exclude light-curve-python --all-targets -- -D warnings
 
 
   python:
@@ -124,7 +124,7 @@ jobs:
       with:
         submodules: true
     - name: build all but python
-      run: cargo build --workspace --all-targets --exclude python/light-curve
+      run: cargo build --workspace --all-targets --exclude light-curve-python
     - name: build python
       run: maturin build
       working-directory: python/light-curve

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Install FFTW and GSL
       run: |
         sudo apt-get update
@@ -63,6 +65,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Install FFTW
       run: |
         sudo apt-get update
@@ -116,9 +120,11 @@ jobs:
     runs-on: [self-hosted, linux, ARM64]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: build all but python
-        run: cargo build --workspace --all-targets --exclude python/light-curve
-      - name: build python
-        run: maturin build
-        working-directory: python/light-curve
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: build all but python
+      run: cargo build --workspace --all-targets --exclude python/light-curve
+    - name: build python
+      run: maturin build
+      working-directory: python/light-curve

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test-data"]
+	path = test-data
+	url = https://github.com/light-curve/test-data.git

--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ The most of the code base is written on Rust and split into several crates.
 
 - `light-curve`**WIP** A crate which will be an umbrella for other Rust crates
 
-- `light-curve-common` ![docs.rs badge](https://docs.rs/light-curve-common/badge.svg) Common tools for other crates
+- `light-curve-common` [![docs.rs badge](https://docs.rs/light-curve-common/badge.svg)](https://docs.rs/light-curve-common) Common tools for other crates
 
-- `light-curve-dmdt` ![docs.rs badge](https://docs.rs/light-curve-dmdt/badge.svg) [dm-dt](https://arxiv.org/abs/1709.06257) mapper crate and executable
+- `light-curve-dmdt` [![docs.rs badge](https://docs.rs/light-curve-dmdt/badge.svg)](https://docs.rs/light-curve-dmdt) [dm-dt](https://arxiv.org/abs/1709.06257) mapper crate and executable
 
-- `light-curve-feature` ![docs.rs badge](https://docs.rs/light-curve-feature/badge.svg) A collection of features to be extracted from light curves
+- `light-curve-feature` [![docs.rs badge](https://docs.rs/light-curve-feature/badge.svg)](https://docs.rs/light-curve-feature) A collection of features to be extracted from light curves
 - `light-curve-interpol`**WIP** Light curve interpolation tools. Currently it includes linear interpolation only
-- `light-curve-python` [![PyPI version](https://badge.fury.io/py/light-curve-python.svg)](https://badge.fury.io/py/light-curve-python) Python bindings to `light-curve-dmdt` and `light-curve-feature`. Note that in the future releases `light-curve-python`Python package will be renamed to `light-curve`.
+- `light-curve-python` [![PyPI version](https://badge.fury.io/py/light-curve-python.svg)](https://pypi.org/project/light-curve-python/) Python bindings to `light-curve-dmdt` and `light-curve-feature`. Note that in the future releases `light-curve-python`Python package will be renamed to `light-curve`.
+- `test-data` is [a Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) linking to [the `test-data` repository](https://github.com/light-curve/test-data) containing light curves required for testing, benchmarking and development of the new features. Use `git clone --recurse-submodules` to download this repo with all submodules
 - `.ci` Continuous integration related stuff, currently it is just a custom Docker [maturin](https://github.com/pyo3/maturin) image used to publish x86-64 Linux Python packages via Github Actions
 - `.github` GitHub related utils, such as dependabot configuration and Actions workflows
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,44 @@
-# Light-curve processing library
+# `light-curve`
+## Irregular time series processing tools for Rust and Python
 
-# Rust
+The project is aimed to build high-performance tools for light curve analysis suitable to process alert and archival data of current [ZTF](https://ztf.caltech.edu) and future [Vera Rubin Observatory LSST](https://lsst.org) photometric surveys.
 
-### `light-curve`
-WIP: will be an umbrella crate for other Rust crates
+The most of the code base is written on Rust and split into several crates.
 
-### `light-curve-feature`
+### Structure
 
-![docs.rs badge](https://docs.rs/light-curve-feature/badge.svg)
+- `light-curve`**WIP** A crate which will be an umbrella for other Rust crates
 
-A collection of features to be extracted from light curves
+- `light-curve-common` ![docs.rs badge](https://docs.rs/light-curve-common/badge.svg) Common tools for other crates
 
-### `light-curve-common`
-Common utilities
+- `light-curve-dmdt` ![docs.rs badge](https://docs.rs/light-curve-dmdt/badge.svg) [dm-dt](https://arxiv.org/abs/1709.06257) mapper crate and executable
 
-### `light-curve-interpol`
-WIP: interpolation utilities, only linear interpolation is available now
+- `light-curve-feature` ![docs.rs badge](https://docs.rs/light-curve-feature/badge.svg) A collection of features to be extracted from light curves
+- `light-curve-interpol`**WIP** Light curve interpolation tools. Currently it includes linear interpolation only
+- `light-curve-python` [![PyPI version](https://badge.fury.io/py/light-curve-python.svg)](https://badge.fury.io/py/light-curve-python) Python bindings to `light-curve-dmdt` and `light-curve-feature`. Note that in the future releases `light-curve-python`Python package will be renamed to `light-curve`.
+- `.ci` Continuous integration related stuff, currently it is just a custom Docker [maturin](https://github.com/pyo3/maturin) image used to publish x86-64 Linux Python packages via Github Actions
+- `.github` GitHub related utils, such as dependabot configuration and Actions workflows
 
-# Python
+### Citation
 
-### `light-curve-python`
+If you found this project useful for your research please cite [Malanchev et al., 2021](https://ui.adsabs.harvard.edu/abs/2021MNRAS.502.5147M/abstract)
 
-[![PyPI version](https://badge.fury.io/py/light-curve-python.svg)](https://pypi.python.org/pypi/light-curve-python/)
-
-Python bindings for `light-curve-feature` Rust crate. Install it by
-
-```sh
-pip3 install light-curve-python
-```
-
-### `python`
-
-WIP: future home for mixed Rust-Python package. Now pure Python implementation is developed here
-
-# How to develop
-
-### Formatting
-
-All Rust code should be formatted by `rustfmt` and should pass `clippy` check.
-
-All Python code should be formatted by `black` with 120 char line-width.
-
-[`pre-commit`](https://pre-commit.com/) can be used for automatically formatting on `git commit`.
-Install Git hooks in the project root via
-```shell
-pip3 install pre-commit
-# OR: pip3 install --user pre-commit
-# OR on macOS: brew install pre-commit
-pre-commit install
+```bibtex
+@ARTICLE{2021MNRAS.502.5147M,
+       author = {{Malanchev}, K.~L. and {Pruzhinskaya}, M.~V. and {Korolev}, V.~S. and {Aleo}, P.~D. and {Kornilov}, M.~V. and {Ishida}, E.~E.~O. and {Krushinsky}, V.~V. and {Mondon}, F. and {Sreejith}, S. and {Volnova}, A.~A. and {Belinski}, A.~A. and {Dodin}, A.~V. and {Tatarnikov}, A.~M. and {Zheltoukhov}, S.~G. and {(The SNAD Team)}},
+        title = "{Anomaly detection in the Zwicky Transient Facility DR3}",
+      journal = {\mnras},
+     keywords = {methods: data analysis, astronomical data bases: miscellaneous, stars: variables: general, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+         year = 2021,
+        month = apr,
+       volume = {502},
+       number = {4},
+        pages = {5147-5175},
+          doi = {10.1093/mnras/stab316},
+archivePrefix = {arXiv},
+       eprint = {2012.01419},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2021MNRAS.502.5147M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 ```

--- a/light-curve-common/Cargo.toml
+++ b/light-curve-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "light-curve-common"
 version = "0.1.1"
 description = "Common tools for light-curve-* packages"
-repository = "https://github.com/hombit/light-curve"
+repository = "https://github.com/light-curve/light-curve"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/light-curve-dmdt/Cargo.toml
+++ b/light-curve-dmdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-curve-dmdt"
-version = "0.2.6"
+version = "0.3.0"
 description = "dm-dt maps generator"
 repository = "https://github.com/hombit/light-curve"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
@@ -26,6 +26,7 @@ harness = false
 [dependencies]
 clap = "^2.33.3"
 conv = "^0.3.3"
+dyn-clonable = "^0.9.0"
 enumflags2 = "^0.7.1"
 itertools = "^0.10.0"
 libm = "^0.2.1" # erf
@@ -35,8 +36,9 @@ png = "^0.16.8"
 thiserror = "^1.0.24"
 
 [dev-dependencies]
-approx = "^0.4.0"
+approx = "^0.5.0"
 criterion = "^0.3"
 libm = "^0.2.1"
-mathru = "^0.8.4"
+mathru = "^0.9.0"
 special = "^0.8.1"
+static_assertions = "^1.1.0"

--- a/light-curve-dmdt/Cargo.toml
+++ b/light-curve-dmdt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "light-curve-dmdt"
 version = "0.3.0"
 description = "dm-dt maps generator"
-repository = "https://github.com/hombit/light-curve"
+repository = "https://github.com/light-curve/light-curve"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/light-curve-dmdt/benches/cond_prob.rs
+++ b/light-curve-dmdt/benches/cond_prob.rs
@@ -1,0 +1,38 @@
+use criterion::{black_box, Criterion};
+use light_curve_dmdt::{DmDt, Eps1Over1e3Erf};
+use ndarray::Array1;
+
+pub fn bench_cond_prob(c: &mut Criterion) {
+    let dmdt = DmDt::from_lgdt_dm_limits(0.0_f32, 2.0_f32, 32, 1.25_f32, 32);
+
+    let t = Array1::linspace(0.0, 100.0, 101);
+    let m = t.mapv(f32::sin);
+    // err is ~0.03
+    let err2 = Array1::from_elem(101, 0.001);
+
+    c.bench_function(
+        "conditional probability = convert_lc_to_gausses() / dt_points()",
+        |b| {
+            b.iter(|| {
+                let mut map = dmdt.gausses::<Eps1Over1e3Erf>(
+                    t.as_slice().unwrap(),
+                    m.as_slice().unwrap(),
+                    err2.as_slice().unwrap(),
+                );
+                let dt_points = dmdt.dt_points(t.as_slice().unwrap());
+                let dt_points_no_zeros = dt_points.mapv(|x| if x == 0 { 1.0 } else { x as f32 });
+                map /= &dt_points_no_zeros.into_shape((map.nrows(), 1)).unwrap();
+                black_box(map);
+            })
+        },
+    );
+    c.bench_function("conditional probability = cond_prob()", |b| {
+        b.iter(|| {
+            black_box(dmdt.cond_prob::<Eps1Over1e3Erf>(
+                t.as_slice().unwrap(),
+                m.as_slice().unwrap(),
+                err2.as_slice().unwrap(),
+            ));
+        })
+    });
+}

--- a/light-curve-dmdt/benches/gausses.rs
+++ b/light-curve-dmdt/benches/gausses.rs
@@ -1,43 +1,50 @@
 use conv::*;
 use criterion::{black_box, Criterion};
-use light_curve_dmdt::{DmDt, ErfFloat, ErrorFunction, Grid};
+use light_curve_dmdt::{DmDt, Eps1Over1e3Erf, ErfFloat, ExactErf};
 use ndarray::Array1;
 
 pub fn bench_gausses<T>(c: &mut Criterion)
 where
     T: ErfFloat + ValueFrom<f32>,
 {
-    let dmdt = DmDt {
-        lgdt_grid: Grid::new(T::zero(), 2.0_f32.value_as::<T>().unwrap(), 32),
-        dm_grid: Grid::new(
-            (-1.25_f32).value_as::<T>().unwrap(),
-            1.25_f32.value_as::<T>().unwrap(),
-            32,
-        ),
-    };
+    let dmdt = DmDt::from_lgdt_dm_limits(
+        T::zero(),
+        2.0_f32.value_as::<T>().unwrap(),
+        32,
+        1.25_f32.value_as::<T>().unwrap(),
+        32,
+    );
 
     let t = Array1::linspace(T::zero(), 100.0_f32.value_as::<T>().unwrap(), 101);
     let m = t.mapv(T::sin);
     // err is ~0.03
     let err2 = Array1::from_elem(101, 0.001_f32.value_as::<T>().unwrap());
 
-    let erfs = [ErrorFunction::Exact, ErrorFunction::Eps1Over1e3];
+    let gausses_methods: [(_, Box<dyn Fn(_, _, _) -> _>); 2] = [
+        (
+            "ExactErf",
+            Box::new(|t, m, err2| dmdt.gausses::<ExactErf>(t, m, err2)),
+        ),
+        (
+            "Eps1Over1e3Erf",
+            Box::new(|t, m, err2| dmdt.gausses::<Eps1Over1e3Erf>(t, m, err2)),
+        ),
+    ];
 
-    for erf in erfs.iter() {
+    for (erf, method) in gausses_methods.iter() {
         c.bench_function(
             format!(
-                "DmDt<{}>::convert_lc_to_gausses, erf type is {:?}",
+                "DmDt<{}>::convert_lc_to_gausses, erf type is {}",
                 std::any::type_name::<T>(),
-                erf
+                erf,
             )
             .as_str(),
             |b| {
                 b.iter(|| {
-                    black_box(dmdt.gausses(
+                    black_box(method(
                         t.as_slice_memory_order().unwrap(),
                         m.as_slice_memory_order().unwrap(),
                         err2.as_slice_memory_order().unwrap(),
-                        &erf,
                     ));
                 })
             },

--- a/light-curve-dmdt/benches/grid.rs
+++ b/light-curve-dmdt/benches/grid.rs
@@ -1,0 +1,61 @@
+use conv::*;
+use criterion::{black_box, Criterion};
+use light_curve_dmdt::{ArrayGrid, DmDt, Float};
+use ndarray::Array1;
+
+pub fn bench_log_linear_grids<T>(c: &mut Criterion)
+where
+    T: Float + ValueFrom<f32>,
+{
+    let dmdt_lg_linear = DmDt::from_lgdt_dm_limits(
+        T::zero(),
+        2.0_f32.value_as::<T>().unwrap(),
+        32,
+        1.25_f32.value_as::<T>().unwrap(),
+        32,
+    );
+    let dmdt_arrays: DmDt<T> = DmDt {
+        dt_grid: Box::new(
+            ArrayGrid::new(Array1::logspace(
+                10.0_f32.value_as::<T>().unwrap(),
+                0.0_f32.value_as::<T>().unwrap(),
+                2.0_f32.value_as::<T>().unwrap(),
+                33,
+            ))
+            .unwrap(),
+        ),
+        dm_grid: Box::new(
+            ArrayGrid::new(Array1::linspace(
+                -(1.25_f32.value_as::<T>().unwrap()),
+                1.25_f32.value_as::<T>().unwrap(),
+                33,
+            ))
+            .unwrap(),
+        ),
+    };
+
+    let t = Array1::linspace(T::zero(), 100.0_f32.value_as::<T>().unwrap(), 101);
+    let m = t.mapv(T::sin);
+
+    c.bench_function(
+        format!(
+            "DmDt<{}>::points, log and linear grids",
+            std::any::type_name::<T>()
+        )
+        .as_str(),
+        |b| {
+            b.iter(|| {
+                black_box(dmdt_lg_linear.points(t.as_slice().unwrap(), m.as_slice().unwrap()));
+            })
+        },
+    );
+
+    c.bench_function(
+        format!("DmDt<{}>::points, array grids", std::any::type_name::<T>()).as_str(),
+        |b| {
+            b.iter(|| {
+                black_box(dmdt_arrays.points(t.as_slice().unwrap(), m.as_slice().unwrap()));
+            })
+        },
+    );
+}

--- a/light-curve-dmdt/benches/lib.rs
+++ b/light-curve-dmdt/benches/lib.rs
@@ -1,12 +1,19 @@
 #[macro_use]
 extern crate criterion;
 
+mod cond_prob;
+use cond_prob::bench_cond_prob;
+
 mod erf;
 use erf::{bench_erf, bench_erfinv};
 
 mod gausses;
 use gausses::bench_gausses;
 
+mod grid;
+use grid::bench_log_linear_grids;
+
+criterion_group!(benches_cond_prob, bench_cond_prob);
 criterion_group!(
     benches_erf,
     bench_erf<f32>,
@@ -15,4 +22,15 @@ criterion_group!(
     bench_erfinv<f64>
 );
 criterion_group!(benches_gausses, bench_gausses<f32>, bench_gausses<f64>);
-criterion_main!(benches_erf, benches_gausses);
+criterion_group!(
+    benches_grid,
+    bench_log_linear_grids<f32>,
+    bench_log_linear_grids<f64>
+);
+
+criterion_main!(
+    benches_cond_prob,
+    benches_erf,
+    benches_gausses,
+    benches_grid
+);

--- a/light-curve-dmdt/src/float_trait.rs
+++ b/light-curve-dmdt/src/float_trait.rs
@@ -1,18 +1,33 @@
 use conv::*;
 
 pub trait Float:
-    ndarray::NdFloat + num_traits::FloatConst + ValueFrom<usize> + ApproxInto<usize, RoundToZero>
+    ndarray::NdFloat
+    + num_traits::FloatConst
+    + num_traits::Signed
+    + num_traits::Float
+    + ValueFrom<usize>
+    + ApproxInto<usize, RoundToZero>
+    + ApproxFrom<u64>
 {
     fn half() -> Self;
+    fn ten() -> Self;
 }
 
 impl Float for f32 {
     fn half() -> Self {
         0.5
     }
+
+    fn ten() -> Self {
+        10.0
+    }
 }
 impl Float for f64 {
     fn half() -> Self {
         0.5
+    }
+
+    fn ten() -> Self {
+        10.0
     }
 }

--- a/light-curve-dmdt/src/lib.rs
+++ b/light-curve-dmdt/src/lib.rs
@@ -1,18 +1,24 @@
+#[cfg(test)]
+#[macro_use]
+extern crate static_assertions;
+
 use conv::*;
+use dyn_clonable::*;
 use itertools::Itertools;
 use ndarray::{s, Array1, Array2, ScalarOperand};
 use std::fmt::Debug;
 use std::io::Write;
+use thiserror::Error;
 
 mod erf;
-pub use erf::{ErfFloat, ErrorFunction};
+pub use erf::{Eps1Over1e3Erf, ErfFloat, ErrorFunction, ExactErf};
 
 mod float_trait;
 pub use float_trait::Float;
 
 pub trait Normalisable:
     ApproxInto<u8, DefaultApprox>
-    + ValueFrom<usize>
+    + ValueFrom<u64>
     + num_traits::Num
     + num_traits::NumOps
     + PartialOrd
@@ -23,7 +29,7 @@ pub trait Normalisable:
     fn max_u8() -> Self;
 }
 
-impl Normalisable for usize {
+impl Normalisable for u64 {
     fn clamp(self, min: Self, max: Self) -> Self {
         match self {
             _ if self < min => min,
@@ -60,18 +66,109 @@ impl Normalisable for f64 {
     }
 }
 
+#[clonable]
+pub trait Grid<T>: Clone + Debug + Send + Sync
+where
+    T: Copy,
+{
+    /// Cell borders coordinates, must be len() + 1 length Array
+    fn get_borders(&self) -> &Array1<T>;
+
+    /// Number of cells
+    fn cell_count(&self) -> usize {
+        self.get_borders().len() - 1
+    }
+
+    /// Coordinate of the left border of the leftmost cell
+    fn get_start(&self) -> T {
+        self.get_borders()[0]
+    }
+
+    /// Coordinate of the right border of the rightmost cell
+    fn get_end(&self) -> T {
+        self.get_borders()[self.cell_count()]
+    }
+
+    /// Get index of the cell containing given value
+    fn idx(&self, x: T) -> CellIndex;
+}
+
+pub fn is_sorted<T>(a: &[T]) -> bool
+where
+    T: PartialOrd,
+{
+    a.iter().tuple_windows().all(|(a, b)| a < b)
+}
+
+#[derive(Error, Debug)]
+pub enum ArrayGridError {
+    #[error("given grid is empty")]
+    ArrayIsEmpty,
+    #[error("given grid is not ascending")]
+    ArrayIsNotAscending,
+}
+
 #[derive(Clone, Debug)]
-pub struct Grid<T> {
-    start: T, // coordinate of the left border of the leftmost cell
-    end: T,   // coordinate of the right border of the rightmost cell
+pub struct ArrayGrid<T>
+where
+    Array1<T>: Clone + Debug,
+{
+    borders: Array1<T>,
+}
+
+impl<T> ArrayGrid<T>
+where
+    Array1<T>: Clone + Debug,
+    T: Float,
+{
+    pub fn new(borders: Array1<T>) -> Result<Self, ArrayGridError> {
+        if borders.is_empty() {
+            return Err(ArrayGridError::ArrayIsEmpty);
+        }
+        if !is_sorted(borders.as_slice().unwrap()) {
+            return Err(ArrayGridError::ArrayIsNotAscending);
+        }
+        Ok(Self { borders })
+    }
+}
+
+impl<T> Grid<T> for ArrayGrid<T>
+where
+    Array1<T>: Clone + Debug,
+    T: Float,
+{
+    #[inline]
+    fn get_borders(&self) -> &Array1<T> {
+        &self.borders
+    }
+
+    fn idx(&self, x: T) -> CellIndex {
+        let i = self
+            .borders
+            .as_slice()
+            .unwrap()
+            .partition_point(|&b| b <= x);
+        match i {
+            0 => CellIndex::LowerMin,
+            _ if i == self.borders.len() => CellIndex::GreaterMax,
+            _ => CellIndex::Value(i - 1),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LinearGrid<T>
+where
+    T: Copy,
+{
+    start: T,
+    end: T,
     n: usize,
-    // length: T, // distance from the left border of the leftmost cell to the right border of the rightmost cell
     cell_size: T,
     borders: Array1<T>,
 }
 
-#[allow(clippy::len_without_is_empty)]
-impl<T> Grid<T>
+impl<T> LinearGrid<T>
 where
     T: Float,
 {
@@ -83,30 +180,39 @@ where
             start,
             end,
             n,
-            // length,
             cell_size,
             borders,
         }
     }
 
-    pub fn len(&self) -> usize {
-        self.n
-    }
-
-    pub fn get_start(&self) -> T {
-        self.start
-    }
-
-    pub fn get_end(&self) -> T {
-        self.end
-    }
-
+    #[inline]
     pub fn get_cell_size(&self) -> T {
         self.cell_size
     }
+}
 
-    pub fn get_borders(&self) -> &Array1<T> {
+impl<T> Grid<T> for LinearGrid<T>
+where
+    T: Float,
+{
+    #[inline]
+    fn get_borders(&self) -> &Array1<T> {
         &self.borders
+    }
+
+    #[inline]
+    fn cell_count(&self) -> usize {
+        self.n
+    }
+
+    #[inline]
+    fn get_start(&self) -> T {
+        self.start
+    }
+
+    #[inline]
+    fn get_end(&self) -> T {
+        self.end
     }
 
     fn idx(&self, x: T) -> CellIndex {
@@ -128,113 +234,296 @@ where
     }
 }
 
-enum CellIndex {
+#[derive(Clone, Debug)]
+pub struct LgGrid<T>
+where
+    T: Copy,
+{
+    start: T,
+    end: T,
+    lg_start: T,
+    lg_end: T,
+    n: usize,
+    cell_lg_size: T,
+    borders: Array1<T>,
+}
+
+impl<T> LgGrid<T>
+where
+    T: Float,
+{
+    pub fn from_start_end(start: T, end: T, n: usize) -> Self {
+        assert!(end > start);
+        assert!(start.is_positive());
+        let lg_start = start.log10();
+        let lg_end = end.log10();
+        let cell_lg_size = (lg_end - lg_start) / n.value_as::<T>().unwrap();
+        let mut borders = Array1::logspace(T::ten(), lg_start, lg_end, n + 1);
+        borders[0] = start;
+        borders[n] = end;
+        Self {
+            start,
+            end,
+            lg_start,
+            lg_end,
+            n,
+            cell_lg_size,
+            borders,
+        }
+    }
+
+    pub fn from_lg_start_end(lg_start: T, lg_end: T, n: usize) -> Self {
+        Self::from_start_end(T::powf(T::ten(), lg_start), T::powf(T::ten(), lg_end), n)
+    }
+
+    #[inline]
+    pub fn get_cell_lg_size(&self) -> T {
+        self.cell_lg_size
+    }
+
+    #[inline]
+    pub fn get_lg_start(&self) -> T {
+        self.lg_start
+    }
+
+    #[inline]
+    pub fn get_lg_end(&self) -> T {
+        self.lg_end
+    }
+}
+
+impl<T> Grid<T> for LgGrid<T>
+where
+    T: Float,
+{
+    #[inline]
+    fn get_borders(&self) -> &Array1<T> {
+        &self.borders
+    }
+
+    #[inline]
+    fn cell_count(&self) -> usize {
+        self.n
+    }
+
+    #[inline]
+    fn get_start(&self) -> T {
+        self.start
+    }
+
+    #[inline]
+    fn get_end(&self) -> T {
+        self.end
+    }
+
+    fn idx(&self, x: T) -> CellIndex {
+        if x < self.start {
+            return CellIndex::LowerMin;
+        }
+        if x >= self.end {
+            return CellIndex::GreaterMax;
+        }
+        let i = ((x.log10() - self.lg_start) / self.cell_lg_size)
+            .approx_by::<RoundToZero>()
+            .unwrap();
+        if i < self.n {
+            CellIndex::Value(i)
+        } else {
+            // x is a bit smaller self.end + float rounding
+            CellIndex::Value(self.n - 1)
+        }
+    }
+}
+
+pub enum CellIndex {
     LowerMin,
     GreaterMax,
     Value(usize),
 }
 
 #[derive(Clone, Debug)]
-pub struct DmDt<T> {
-    pub lgdt_grid: Grid<T>,
-    pub dm_grid: Grid<T>,
+pub struct DmDt<T>
+where
+    T: Copy,
+{
+    pub dt_grid: Box<dyn Grid<T>>,
+    pub dm_grid: Box<dyn Grid<T>>,
 }
 
 impl<T> DmDt<T>
 where
     T: Float,
 {
-    /// N lg_dt by N dm
-    pub fn shape(&self) -> (usize, usize) {
-        (self.lgdt_grid.n, self.dm_grid.n)
+    pub fn from_grids<Gdt, Gdm>(dt_grid: Gdt, dm_grid: Gdm) -> Self
+    where
+        Gdt: Grid<T> + 'static,
+        Gdm: Grid<T> + 'static,
+    {
+        Self {
+            dt_grid: Box::new(dt_grid),
+            dm_grid: Box::new(dm_grid),
+        }
     }
 
-    pub fn points(&self, t: &[T], m: &[T]) -> Array2<usize> {
-        let mut a = Array2::zeros((self.lgdt_grid.n, self.dm_grid.n));
+    /// lg dt (10**min_lgdt, 10**max_lgdt) - linear dm (-max_abs_dm, max_abs_dm)
+    pub fn from_lgdt_dm_limits(
+        min_lgdt: T,
+        max_lgdt: T,
+        lgdt_size: usize,
+        max_abs_dm: T,
+        dm_size: usize,
+    ) -> Self {
+        Self::from_grids(
+            LgGrid::from_lg_start_end(min_lgdt, max_lgdt, lgdt_size),
+            LinearGrid::new(-max_abs_dm, max_abs_dm, dm_size),
+        )
+    }
+
+    /// N dt by N dm
+    pub fn shape(&self) -> (usize, usize) {
+        (self.dt_grid.cell_count(), self.dm_grid.cell_count())
+    }
+
+    pub fn points(&self, t: &[T], m: &[T]) -> Array2<u64> {
+        let mut a = Array2::zeros(self.shape());
         for (i1, (&x1, &y1)) in t.iter().zip(m.iter()).enumerate() {
             for (&x2, &y2) in t[i1 + 1..].iter().zip(m[i1 + 1..].iter()) {
-                let lgdt = T::log10(x2 - x1);
-                let idx_lgdt = match self.lgdt_grid.idx(lgdt) {
+                let dt = x2 - x1;
+                let idx_dt = match self.dt_grid.idx(dt) {
                     CellIndex::LowerMin => continue,
                     CellIndex::GreaterMax => break,
-                    CellIndex::Value(idx_lgdt) => idx_lgdt,
+                    CellIndex::Value(idx_dt) => idx_dt,
                 };
                 let dm = y2 - y1;
                 let idx_dm = match self.dm_grid.idx(dm) {
                     CellIndex::Value(idx_dm) => idx_dm,
                     CellIndex::LowerMin | CellIndex::GreaterMax => continue,
                 };
-                a[(idx_lgdt, idx_dm)] += 1;
+                a[(idx_dt, idx_dm)] += 1;
             }
         }
         a
     }
 
-    pub fn gausses(&self, t: &[T], m: &[T], err2: &[T], erf: &ErrorFunction) -> Array2<T>
+    fn update_gausses_helper<Erf>(
+        &self,
+        a: &mut Array2<T>,
+        idx_dt: usize,
+        y1: T,
+        y2: T,
+        d1: T,
+        d2: T,
+    ) where
+        T: ErfFloat,
+        Erf: ErrorFunction<T>,
+    {
+        let dm = y2 - y1;
+        let dm_err = T::sqrt(d1 + d2);
+
+        let min_idx_dm = match self
+            .dm_grid
+            .idx(dm + Erf::min_dx_nonzero_normal_cdf(dm_err))
+        {
+            CellIndex::LowerMin => 0,
+            CellIndex::GreaterMax => return,
+            CellIndex::Value(min_idx_dm) => min_idx_dm,
+        };
+        let max_idx_dm = match self
+            .dm_grid
+            .idx(dm + Erf::max_dx_nonunity_normal_cdf(dm_err))
+        {
+            CellIndex::LowerMin => return,
+            CellIndex::GreaterMax => self.dm_grid.cell_count(),
+            CellIndex::Value(i) => usize::min(i + 1, self.dm_grid.cell_count()),
+        };
+
+        a.slice_mut(s![idx_dt, min_idx_dm..max_idx_dm])
+            .iter_mut()
+            .zip(
+                self.dm_grid
+                    .get_borders()
+                    .slice(s![min_idx_dm..max_idx_dm + 1])
+                    .iter()
+                    .map(|&dm_border| Erf::normal_cdf(dm_border, dm, dm_err))
+                    .tuple_windows()
+                    .map(|(a, b)| b - a),
+            )
+            .for_each(|(cell, value)| *cell += value);
+    }
+
+    pub fn gausses<Erf>(&self, t: &[T], m: &[T], err2: &[T]) -> Array2<T>
     where
         T: ErfFloat,
+        Erf: ErrorFunction<T>,
     {
-        let mut a = Array2::zeros((self.lgdt_grid.n, self.dm_grid.n));
+        let mut a = Array2::zeros(self.shape());
         for (i1, ((&x1, &y1), &d1)) in t.iter().zip(m.iter()).zip(err2.iter()).enumerate() {
             for ((&x2, &y2), &d2) in t[i1 + 1..]
                 .iter()
                 .zip(m[i1 + 1..].iter())
                 .zip(err2[i1 + 1..].iter())
             {
-                let lgdt = T::log10(x2 - x1);
-                let idx_lgdt = match self.lgdt_grid.idx(lgdt) {
+                let dt = x2 - x1;
+                let idx_dt = match self.dt_grid.idx(dt) {
                     CellIndex::LowerMin => continue,
                     CellIndex::GreaterMax => break,
-                    CellIndex::Value(idx_lgdt) => idx_lgdt,
+                    CellIndex::Value(idx_dt) => idx_dt,
                 };
-                let dm = y2 - y1;
-                let dm_err = T::sqrt(d1 + d2);
-
-                let min_idx_dm = match self.dm_grid.idx(dm + erf.min_dx_nonzero_normal_cdf(dm_err))
-                {
-                    CellIndex::LowerMin => 0,
-                    CellIndex::GreaterMax => continue,
-                    CellIndex::Value(min_idx_dm) => min_idx_dm,
-                };
-                let max_idx_dm = match self
-                    .dm_grid
-                    .idx(dm + erf.max_dx_nonunity_normal_cdf(dm_err))
-                {
-                    CellIndex::LowerMin => continue,
-                    CellIndex::GreaterMax => self.dm_grid.n,
-                    CellIndex::Value(i) => usize::min(i + 1, self.dm_grid.n),
-                };
-
-                a.slice_mut(s![idx_lgdt, min_idx_dm..max_idx_dm])
-                    .iter_mut()
-                    .zip(
-                        self.dm_grid
-                            .borders
-                            .slice(s![min_idx_dm..max_idx_dm + 1])
-                            .iter()
-                            .map(|&dm_border| erf.normal_cdf(dm_border, dm, dm_err))
-                            .tuple_windows()
-                            .map(|(a, b)| b - a),
-                    )
-                    .for_each(|(cell, value)| *cell += value);
+                self.update_gausses_helper::<Erf>(&mut a, idx_dt, y1, y2, d1, d2);
             }
         }
         a
     }
 
-    pub fn lgdt_points(&self, t: &[T]) -> Array1<usize> {
-        let mut a = Array1::zeros(self.lgdt_grid.n);
+    pub fn dt_points(&self, t: &[T]) -> Array1<u64> {
+        let mut a = Array1::zeros(self.dt_grid.cell_count());
         for (i1, &x1) in t.iter().enumerate() {
             for &x2 in t[i1 + 1..].iter() {
-                let lgdt = T::log10(x2 - x1);
-                let idx_lgdt = match self.lgdt_grid.idx(lgdt) {
+                let dt = x2 - x1;
+                let idx_dt = match self.dt_grid.idx(dt) {
                     CellIndex::LowerMin => continue,
                     CellIndex::GreaterMax => break,
-                    CellIndex::Value(idx_lgdt) => idx_lgdt,
+                    CellIndex::Value(idx_dt) => idx_dt,
                 };
-                a[idx_lgdt] += 1;
+                a[idx_dt] += 1;
             }
         }
+        a
+    }
+
+    pub fn cond_prob<Erf>(&self, t: &[T], m: &[T], err2: &[T]) -> Array2<T>
+    where
+        T: ErfFloat,
+        Erf: ErrorFunction<T>,
+    {
+        let mut a: Array2<T> = Array2::zeros(self.shape());
+        let mut dt_points: Array1<u64> = Array1::zeros(self.dt_grid.cell_count());
+        for (i1, ((&x1, &y1), &d1)) in t.iter().zip(m.iter()).zip(err2.iter()).enumerate() {
+            for ((&x2, &y2), &d2) in t[i1 + 1..]
+                .iter()
+                .zip(m[i1 + 1..].iter())
+                .zip(err2[i1 + 1..].iter())
+            {
+                let dt = x2 - x1;
+                let idx_dt = match self.dt_grid.idx(dt) {
+                    CellIndex::LowerMin => continue,
+                    CellIndex::GreaterMax => break,
+                    CellIndex::Value(idx_dt) => idx_dt,
+                };
+
+                dt_points[idx_dt] += 1;
+
+                self.update_gausses_helper::<Erf>(&mut a, idx_dt, y1, y2, d1, d2);
+            }
+        }
+        ndarray::Zip::from(a.genrows_mut())
+            .and(&dt_points)
+            .apply(|mut row, &count| {
+                if count == 0 {
+                    return;
+                }
+                row /= T::approx_from(count).unwrap();
+            });
         a
     }
 }
@@ -252,6 +541,88 @@ where
     encoder.set_color(png::ColorType::Grayscale);
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder.write_header()?;
-    writer.write_image_data(transposed.as_slice_memory_order().unwrap())?;
+    writer.write_image_data(transposed.as_slice().unwrap())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::erf::{Eps1Over1e3Erf, ExactErf};
+    use approx::assert_abs_diff_eq;
+    use ndarray::Axis;
+
+    assert_impl_all!(DmDt<f32>: Clone, Debug, Send, Sync);
+    assert_impl_all!(DmDt<f64>: Clone, Debug, Send, Sync);
+
+    #[test]
+    fn dt_points_vs_points() {
+        let dmdt = DmDt::from_lgdt_dm_limits(0.0_f32, 2.0_f32, 32, 3.0_f32, 32);
+        let t = Array1::linspace(0.0, 100.0, 101);
+        // dm is within map borders
+        let m = t.mapv(f32::sin);
+
+        let points = dmdt.points(t.as_slice().unwrap(), m.as_slice().unwrap());
+        let dt_points = dmdt.dt_points(t.as_slice().unwrap());
+
+        assert_eq!(points.sum_axis(Axis(1)), dt_points,);
+    }
+
+    #[test]
+    fn dt_points_vs_gausses() {
+        let dmdt = DmDt::from_lgdt_dm_limits(0.0_f32, 2.0_f32, 32, 3.0_f32, 32);
+        let t = Array1::linspace(0.0, 100.0, 101);
+        // dm is within map borders
+        let m = t.mapv(f32::sin);
+        // err is ~0.03
+        let err2 = Array1::from_elem(101, 0.001_f32);
+
+        let gausses = dmdt.gausses::<ExactErf>(
+            t.as_slice().unwrap(),
+            m.as_slice().unwrap(),
+            err2.as_slice().unwrap(),
+        );
+        let sum_gausses = gausses.sum_axis(Axis(1));
+        let dt_points = dmdt.dt_points(t.as_slice().unwrap()).mapv(|x| x as f32);
+
+        assert_abs_diff_eq!(
+            sum_gausses.as_slice().unwrap(),
+            dt_points.as_slice().unwrap(),
+            epsilon = 1e-4,
+        );
+    }
+
+    #[test]
+    fn cond_prob() {
+        let dmdt = DmDt::from_lgdt_dm_limits(0.0_f32, 2.0_f32, 32, 1.25_f32, 32);
+
+        let t = Array1::linspace(0.0, 100.0, 101);
+        let m = t.mapv(f32::sin);
+        // err is ~0.03
+        let err2 = Array1::from_elem(101, 0.001);
+
+        let from_gausses_dt_points = {
+            let mut map = dmdt.gausses::<Eps1Over1e3Erf>(
+                t.as_slice().unwrap(),
+                m.as_slice().unwrap(),
+                err2.as_slice_memory_order().unwrap(),
+            );
+            let dt_points = dmdt.dt_points(t.as_slice().unwrap());
+            let dt_non_zero_points = dt_points.mapv(|x| if x == 0 { 1.0 } else { x as f32 });
+            map /= &dt_non_zero_points.into_shape((map.nrows(), 1)).unwrap();
+            map
+        };
+
+        let from_cond_prob = dmdt.cond_prob::<Eps1Over1e3Erf>(
+            t.as_slice().unwrap(),
+            m.as_slice().unwrap(),
+            err2.as_slice().unwrap(),
+        );
+
+        assert_abs_diff_eq!(
+            from_gausses_dt_points.as_slice().unwrap(),
+            from_cond_prob.as_slice().unwrap(),
+            epsilon = std::f32::EPSILON,
+        );
+    }
 }

--- a/light-curve-feature/Cargo.toml
+++ b/light-curve-feature/Cargo.toml
@@ -2,7 +2,7 @@
 name = "light-curve-feature"
 version = "0.2.2"
 description = "Feature extractor from noisy time series"
-repository = "https://github.com/hombit/light-curve"
+repository = "https://github.com/light-curve/light-curve"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 license = "GPL-3.0-or-later"
 edition = "2018"

--- a/light-curve-feature/Cargo.toml
+++ b/light-curve-feature/Cargo.toml
@@ -22,7 +22,7 @@ conv = "^0.3.3"
 dyn-clonable = "^0.9.0"
 fftw = { version = "0.7.0", default-features = false }
 GSL = { version = "~4.0.0", default-features = false, optional = true }
-hyperdual = { version = "~0.3.6", optional = true }
+hyperdual = { version = "~0.4.1", optional = true }
 itertools = "^0.10.0"
 lazy_static = "^1.4.0"
 libm = "~0.2.1"

--- a/light-curve-feature/benches/extractor.rs
+++ b/light-curve-feature/benches/extractor.rs
@@ -86,7 +86,7 @@ fn run<T: Float>(
     err: &[T],
 ) -> Result<Vec<T>, EvaluatorError> {
     let w: Vec<_> = err.iter().map(|&e| e.powi(-2)).collect();
-    let mut ts = TimeSeries::new(&x, &y, Some(&w));
+    let mut ts = TimeSeries::new(x, y, Some(&w));
     fe.eval(&mut ts)
 }
 

--- a/light-curve-feature/benches/lib.rs
+++ b/light-curve-feature/benches/lib.rs
@@ -19,11 +19,7 @@ use recurrent_sin_cos::bench_recurrent_sin_cos;
 mod statistics;
 use statistics::bench_peak_indices;
 
-criterion_group!(
-    benches_extractor,
-    bench_extractor<f32>,
-    bench_extractor<f64>
-);
+criterion_group!(benches_extractor, bench_extractor<f64>);
 criterion_group!(benches_fft, bench_fft<f32>, bench_fft<f64>);
 criterion_group!(benches_fit, bench_fit_straight_line);
 criterion_group!(benches_periodogram, bench_periodogram);

--- a/light-curve-feature/src/fit/straight_line.rs
+++ b/light-curve-feature/src/fit/straight_line.rs
@@ -25,20 +25,20 @@ pub fn fit_straight_line<T: Float>(
         }
         (n, sx, sy)
     };
-    let (stt, sty) = if known_errors & ts.w.is_some() {
+    let (stt, sty) = {
         let (mut stt, mut sty) = (T::zero(), T::zero());
-        for (x, y, w) in ts.tmw_iter() {
-            let t = x - sx / s;
-            stt += w * t.powi(2);
-            sty += w * t * y;
-        }
-        (stt, sty)
-    } else {
-        let (mut stt, mut sty) = (T::zero(), T::zero());
-        for (x, y) in ts.tm_iter() {
-            let t = x - sx / s;
-            stt += t.powi(2);
-            sty += t * y;
+        if known_errors & ts.w.is_some() {
+            for (x, y, w) in ts.tmw_iter() {
+                let t = x - sx / s;
+                stt += w * t.powi(2);
+                sty += w * t * y;
+            }
+        } else {
+            for (x, y) in ts.tm_iter() {
+                let t = x - sx / s;
+                stt += t.powi(2);
+                sty += t * y;
+            }
         }
         (stt, sty)
     };

--- a/light-curve-feature/src/lib.rs
+++ b/light-curve-feature/src/lib.rs
@@ -10,8 +10,8 @@
 //! // Define light curve
 //! let time = [0.0, 1.0, 2.0, 3.0, 4.0];
 //! let magn = [-1.0, 2.0, 1.0, 3.0, 4.5];
-//! let magn_err_squared = [0.2, 0.1, 0.5, 0.1, 0.2];
-//! let mut ts = TimeSeries::new(&time[..], &magn[..], Some(&magn_err_squared[..]));
+//! let weights = [5.0, 10.0, 2.0, 10.0, 5.0]; // inversed squared magnitude errors
+//! let mut ts = TimeSeries::new(&time[..], &magn[..], Some(&weights[..]));
 //! // Get results and print
 //! let result = fe.eval(&mut ts)?;
 //! let names = fe.get_names();

--- a/light-curve-feature/src/periodogram/power_fft.rs
+++ b/light-curve-feature/src/periodogram/power_fft.rs
@@ -72,7 +72,7 @@ where
             return vec![T::zero(); freq.size.next_power_of_two()];
         }
 
-        let grid = TimeGrid::from_freq_grid(&freq);
+        let grid = TimeGrid::from_freq_grid(freq);
 
         let mut periodogram_arrays_map = self
             .arrays

--- a/light-curve-interpol/Cargo.toml
+++ b/light-curve-interpol/Cargo.toml
@@ -2,7 +2,7 @@
 name = "light-curve-interpol"
 version = "0.1.1"
 description = "Interpolations tools for time series"
-repository = "https://github.com/hombit/light-curve"
+repository = "https://github.com/light-curve/light-curve"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -2,7 +2,7 @@
 name = "light-curve"
 version = "0.0.0"
 description = "Placeholder for future package. See light-curve-* packages"
-repository = "https://github.com/hombit/light-curve"
+repository = "https://github.com/light-curve/light-curve"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/python/light-curve/Cargo.toml
+++ b/python/light-curve/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0-alpha.2"
 edition = "2018"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 description = "Feature extractor from noisy time series"
-repository = "https://github.com/hombit/light-curve"
+repository = "https://github.com/light-curve/light-curve"
 license = "GPL-3.0-or-later"
 
 [lib]

--- a/python/light-curve/Cargo.toml
+++ b/python/light-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-curve-python"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 edition = "2018"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 description = "Feature extractor from noisy time series"
@@ -15,16 +15,17 @@ crate-type = ["cdylib"]
 default = ["fftw-static"]
 fftw-static = ["light-curve-feature/fftw-source"]
 fftw-dynamic = ["light-curve-feature/fftw-system"]
-mkl-dynamic = ["light-curve-feature/fftw-mkl"]
+mkl = ["light-curve-feature/fftw-mkl"]
 nonlinear-fit = ["light-curve-feature/gsl"]
 
 [dependencies]
 conv = "^0.3.3"
 enumflags2 = "^0.7.1"
 itertools = "~0.10"
-light-curve-dmdt = "0.2.5"
+light-curve-dmdt = "0.3.0"
 ndarray = { version = "^0.14.0", features = ["rayon"] }
-numpy = "^0.13"
+# numpy 0.13.2 brings ndarray 0.15 which is not compatible with light-curve-dmdt
+numpy = "=0.13.1"
 num_cpus = "^1.13.0"
 num-traits = "^0.2"
 rand = "^0.8.3"

--- a/python/light-curve/light_curve/__init__.py
+++ b/python/light-curve/light_curve/__init__.py
@@ -1,2 +1,7 @@
 from .light_curve_py import *
+
+# Hide Python features with Rust equivalents
 from .light_curve_ext import *
+
+# Hide Rust Extractor with universal Python Extractor
+from .light_curve_py import Extractor

--- a/python/light-curve/light_curve/light_curve_py/features/_base.py
+++ b/python/light-curve/light_curve/light_curve_py/features/_base.py
@@ -1,25 +1,7 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Collection
-
-import numpy as np
 
 
 class BaseFeature(ABC):
     @abstractmethod
     def __call__(self, t, m, sigma=None, sorted=None, fill_value=None):
         pass
-
-
-@dataclass
-class BaseMetaFeature(BaseFeature):
-    features: Collection[BaseFeature] = ()
-
-    @abstractmethod
-    def transform(self, t, m, sigma):
-        pass
-
-    def __call__(self, t, m, sigma=None, sorted=None, fill_value=None):
-        t, m, sigma = self.transform(t, m, sigma)
-        result = np.concatenate([np.atleast_1d(feature(t, m, sigma)) for feature in self.features])
-        return result

--- a/python/light-curve/light_curve/light_curve_py/features/_base_meta.py
+++ b/python/light-curve/light_curve/light_curve_py/features/_base_meta.py
@@ -1,0 +1,25 @@
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from typing import Collection, Union
+
+from ._base import BaseFeature
+from .extractor import Extractor, _PyExtractor
+from light_curve.light_curve_ext import Extractor as _RustExtractor, _FeatureEvaluator as _RustBaseFeature
+
+
+@dataclass
+class BaseMetaFeature(BaseFeature):
+    features: Collection[Union[BaseFeature, _RustBaseFeature]] = ()
+    extractor: Union[_RustExtractor, _PyExtractor] = field(init=False)
+
+    def __post_init__(self):
+        self.extractor = Extractor(self.features)
+
+    @abstractmethod
+    def transform(self, t, m, sigma):
+        """Must return temporarily sorted arrays (t, m, sigma)"""
+        pass
+
+    def __call__(self, t, m, sigma=None, sorted=None, fill_value=None):
+        t, m, sigma = self.transform(t, m, sigma)
+        return self.extractor(t, m, sigma, sorted=True, fill_value=fill_value)

--- a/python/light-curve/light_curve/light_curve_py/features/bins.py
+++ b/python/light-curve/light_curve/light_curve_py/features/bins.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import ndimage
 from dataclasses import dataclass
 
-from ._base import BaseMetaFeature
+from ._base_meta import BaseMetaFeature
 
 
 @dataclass()

--- a/python/light-curve/light_curve/light_curve_py/features/extractor.py
+++ b/python/light-curve/light_curve/light_curve_py/features/extractor.py
@@ -1,12 +1,28 @@
 from dataclasses import dataclass
+from typing import Collection, Union
 
-from ._base import BaseMetaFeature
+import numpy as np
+
+from ._base import BaseFeature
+from light_curve.light_curve_ext import Extractor as _RustExtractor, _FeatureEvaluator as _RustBaseFeature
 
 
 @dataclass()
-class Extractor(BaseMetaFeature):
-    def transform(self, t, m, sigma):
-        return t, m, sigma
+class _PyExtractor(BaseFeature):
+    features: Collection[Union[BaseFeature, _RustBaseFeature]] = ()
+
+    def __call__(self, t, m, sigma=None, sorted=None, fill_value=None):
+        return np.concatenate(
+            [np.atleast_1d(feature(t, m, sigma, sorted=sorted, fill_value=fill_value)) for feature in self.features]
+        )
+
+
+class Extractor:
+    def __new__(cls, features: Collection[Union[BaseFeature, _RustBaseFeature]]):
+        if all(isinstance(feature, _RustBaseFeature) for feature in features):
+            return _RustExtractor(features)
+        else:
+            return _PyExtractor(features)
 
 
 __all__ = ("Extractor",)

--- a/python/light-curve/light_curve/light_curve_py/features/extractor.py
+++ b/python/light-curve/light_curve/light_curve_py/features/extractor.py
@@ -19,7 +19,7 @@ class _PyExtractor(BaseFeature):
 
 class Extractor:
     def __new__(cls, features: Collection[Union[BaseFeature, _RustBaseFeature]]):
-        if all(isinstance(feature, _RustBaseFeature) for feature in features):
+        if len(features) > 0 and all(isinstance(feature, _RustBaseFeature) for feature in features):
             return _RustExtractor(features)
         else:
             return _PyExtractor(features)

--- a/python/light-curve/pyproject.toml
+++ b/python/light-curve/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin >= 0.8.0"]
+requires = ["maturin>=0.10,<0.11"]
 build-backend = "maturin"
 
 [tool.black]

--- a/python/light-curve/src/dmdt.rs
+++ b/python/light-curve/src/dmdt.rs
@@ -95,7 +95,7 @@ where
 
     fn normalize(&self, a: &mut ndarray::Array2<T>, t: &[T]) {
         if self.norm.contains(NormFlag::Dt) {
-            let dt = self.dmdt.dt_points(&t);
+            let dt = self.dmdt.dt_points(t);
             let dt_no_zeros = dt.mapv(|x| {
                 if x == 0 {
                     T::one()
@@ -185,7 +185,7 @@ where
         check_sorted(t, sorted)?;
 
         let mut result = self.dmdt.points(t, m).mapv(|x| x.approx_into().unwrap());
-        self.normalize(&mut result, &t);
+        self.normalize(&mut result, t);
         Ok(result)
     }
 
@@ -347,10 +347,10 @@ where
         check_sorted(t, sorted)?;
 
         let mut result = match self.error_func {
-            ErrorFunction::Exact => self.dmdt.gausses::<lcdmdt::ExactErf>(&t, &m, err2),
-            ErrorFunction::Eps1Over1e3 => self.dmdt.gausses::<lcdmdt::Eps1Over1e3Erf>(&t, &m, err2),
+            ErrorFunction::Exact => self.dmdt.gausses::<lcdmdt::ExactErf>(t, m, err2),
+            ErrorFunction::Eps1Over1e3 => self.dmdt.gausses::<lcdmdt::Eps1Over1e3Erf>(t, m, err2),
         };
-        self.normalize(&mut result, &t);
+        self.normalize(&mut result, t);
         Ok(result)
     }
 

--- a/python/light-curve/src/errors.rs
+++ b/python/light-curve/src/errors.rs
@@ -1,4 +1,6 @@
-use pyo3::exceptions::{PyNotImplementedError, PyRuntimeError, PyTypeError, PyValueError};
+use pyo3::exceptions::{
+    PyIndexError, PyNotImplementedError, PyRuntimeError, PyTypeError, PyValueError,
+};
 use pyo3::PyErr;
 use std::fmt::Debug;
 use std::result::Result;
@@ -8,6 +10,7 @@ use thiserror::Error;
 #[derive(Clone, Error, Debug)]
 #[error("{0}")]
 pub enum Exception {
+    IndexError(String),
     NotImplementedError(String),
     RuntimeError(String),
     TypeError(String),
@@ -17,6 +20,7 @@ pub enum Exception {
 impl std::convert::From<Exception> for PyErr {
     fn from(err: Exception) -> PyErr {
         match err {
+            Exception::IndexError(err) => PyIndexError::new_err(err),
             Exception::NotImplementedError(err) => PyNotImplementedError::new_err(err),
             Exception::RuntimeError(err) => PyRuntimeError::new_err(err),
             Exception::TypeError(err) => PyTypeError::new_err(err),

--- a/python/light-curve/src/sorted.rs
+++ b/python/light-curve/src/sorted.rs
@@ -18,7 +18,7 @@ where
             "sorting is not implemented, please provide time-sorted arrays",
         ))),
         None => {
-            if is_sorted(&a) {
+            if is_sorted(a) {
                 Ok(())
             } else {
                 Err(Exception::ValueError(String::from(

--- a/python/light-curve/tests/light_curve_ext/test_dmdt.py
+++ b/python/light-curve/tests/light_curve_ext/test_dmdt.py
@@ -1,23 +1,35 @@
+from itertools import product
+
+try:
+    from contextlib import nullcontext
+except ImportError:
+    from contextlib import contextmanager
+
+    @contextmanager
+    def nullcontext(enter_result=None):
+        yield enter_result
+
+
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 from light_curve.light_curve_ext import DmDt
 
 
-def random_lc(n, sigma=True, rng=None):
+def random_lc(n, sigma=True, rng=None, dtype=np.float64):
     rng = np.random.default_rng(rng)
-    t = np.sort(rng.uniform(0, 10, n))
-    m = rng.normal(0, 1, n)
+    t = np.sort(np.asarray(rng.uniform(0, 10, n), dtype=dtype))
+    m = np.asarray(rng.normal(0, 1, n), dtype=dtype)
     lc = (t, m)
     if sigma:
-        sigma = rng.uniform(0.01, 0.1, n)
+        sigma = np.asarray(rng.uniform(0.01, 0.1, n), dtype=dtype)
         lc += (sigma,)
     return lc
 
 
-def sine_lc(n, sigma=True):
-    t = np.linspace(0, 10, n)
+def sine_lc(n, sigma=True, dtype=np.float64):
+    t = np.asarray(np.linspace(0, 10, n), dtype=dtype)
     m = np.sin(t)
     lc = (t, m)
     if sigma:
@@ -26,41 +38,94 @@ def sine_lc(n, sigma=True):
     return lc
 
 
-def test_dmdt_count_lgdt_three_obs():
-    dmdt = DmDt(min_lgdt=0, max_lgdt=np.log10(3), max_abs_dm=1, lgdt_size=2, dm_size=32, norm=[])
+def test_dmdt_count_dt_three_obs():
+    dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=np.log10(3), max_abs_dm=1, lgdt_size=2, dm_size=32, norm=[])
 
     t = np.array([0, 1, 2], dtype=np.float32)
 
     desired = np.array([2, 1])
-    actual = dmdt.count_lgdt(t)
+    actual = dmdt.count_dt(t)
 
     assert_array_equal(actual, desired)
 
 
-@pytest.mark.parametrize("lc", [sine_lc(101), random_lc(101)])
-def test_dmdt_count_lgdt_many_one(lc):
-    dmdt = DmDt(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=[])
+def test_log_linear_grids():
+    lc = random_lc(101)
 
-    desired = dmdt.count_lgdt(lc[0])
+    min_lgdt = -1
+    max_lgdt = 1
+    lgdt_size = 32
+    max_abs_dm = 2
+    dm_size = 32
+
+    min_dt = 10 ** min_lgdt
+    max_dt = 10 ** max_lgdt
+
+    dt_grid = np.logspace(min_lgdt, max_lgdt, lgdt_size + 1)
+    dm_grid = np.linspace(-max_abs_dm, max_abs_dm, dm_size + 1)
+
+    dmdt_from_borders = DmDt.from_borders(
+        min_lgdt=min_lgdt, max_lgdt=max_lgdt, max_abs_dm=max_abs_dm, lgdt_size=lgdt_size, dm_size=dm_size
+    )
+    dmdt_auto = DmDt(dt=dt_grid, dm=dm_grid, dt_type="auto", dm_type="auto")
+    dmdt_log_linear = DmDt(dt=dt_grid, dm=dm_grid, dt_type="log", dm_type="linear")
+    dmdt_asis = DmDt(dt=dt_grid, dm=dm_grid, dt_type="asis", dm_type="asis")
+
+    for dmdt in (
+        dmdt_from_borders,
+        dmdt_auto,
+        dmdt_log_linear,
+        dmdt_asis,
+    ):
+        assert_allclose(dmdt.min_dt, min_dt)
+        assert_allclose(dmdt.max_dt, max_dt)
+        assert_allclose(dmdt.min_dm, -max_abs_dm)
+        assert_allclose(dmdt.max_dm, max_abs_dm)
+        assert_allclose(dmdt.dt_grid, dt_grid)
+        assert_allclose(dmdt.dm_grid, dm_grid)
+
+    points = dmdt_from_borders.points(lc[0], lc[1])
+    gausses = dmdt_from_borders.gausses(*lc)
+    for dmdt in (
+        dmdt_auto,
+        dmdt_log_linear,
+        dmdt_asis,
+    ):
+        assert_allclose(dmdt.points(lc[0], lc[1]), points)
+        assert_allclose(dmdt.gausses(*lc), gausses)
+
+
+@pytest.mark.parametrize("lc", [sine_lc(101), random_lc(101), sine_lc(101, dtype=np.float32)])
+def test_dmdt_count_dt_many_one(lc):
+    dmdt = DmDt.from_borders(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=[])
+
+    desired = dmdt.count_dt(lc[0])
     assert np.any(desired != 0)
-    actual = dmdt.count_lgdt_many([lc[0]])
+    actual = dmdt.count_dt_many([lc[0]])
 
     assert actual.shape[0] == 1
     assert_array_equal(actual[0], desired)
 
 
-@pytest.mark.parametrize("lcs", [[sine_lc(101), sine_lc(11)], [random_lc(101), random_lc(101), random_lc(11)]])
-def test_dmdt_count_lgdt_many(lcs):
-    dmdt = DmDt(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=[])
+@pytest.mark.parametrize(
+    "lcs",
+    [
+        [sine_lc(101), sine_lc(11)],
+        [random_lc(101), random_lc(101), random_lc(11)],
+        [sine_lc(101, dtype=np.float32), sine_lc(11, dtype=np.float32)],
+    ],
+)
+def test_dmdt_count_dt_many(lcs):
+    dmdt = DmDt.from_borders(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=[])
 
-    desired = [dmdt.count_lgdt(t) for t, *_ in lcs]
-    actual = dmdt.count_lgdt_many([t for t, *_ in lcs])
+    desired = [dmdt.count_dt(t) for t, *_ in lcs]
+    actual = dmdt.count_dt_many([t for t, *_ in lcs])
 
     assert_array_equal(actual, desired)
 
 
 def test_dmdt_points_three_obs():
-    dmdt = DmDt(min_lgdt=0, max_lgdt=np.log10(3), max_abs_dm=3, lgdt_size=2, dm_size=4, norm=[])
+    dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=np.log10(3), max_abs_dm=3, lgdt_size=2, dm_size=4, norm=[])
 
     t = np.array([0, 1, 2], dtype=np.float32)
     m = np.array([0, 1, 2], dtype=np.float32)
@@ -76,10 +141,10 @@ def test_dmdt_points_three_obs():
     assert_array_equal(actual, desired)
 
 
-@pytest.mark.parametrize("lc", [sine_lc(101, False), random_lc(101, False)])
-@pytest.mark.parametrize("norm", [[], ["lgdt"], ["max"], ["lgdt", "max"]])
+@pytest.mark.parametrize("lc", [sine_lc(101, False), random_lc(101, False), sine_lc(101, False, dtype=np.float32)])
+@pytest.mark.parametrize("norm", [[], ["dt"], ["max"], ["dt", "max"]])
 def test_dmdt_points_many_one(lc, norm):
-    dmdt = DmDt(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=norm)
+    dmdt = DmDt.from_borders(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=norm)
 
     desired = dmdt.points(*lc)
     assert np.any(desired != 0)
@@ -91,11 +156,15 @@ def test_dmdt_points_many_one(lc, norm):
 
 @pytest.mark.parametrize(
     "lcs",
-    [[sine_lc(101, False), sine_lc(11, False)], [random_lc(101, False), random_lc(101, False), random_lc(11, False)]],
+    [
+        [sine_lc(101, False), sine_lc(11, False)],
+        [random_lc(101, False), random_lc(101, False), random_lc(11, False)],
+        [sine_lc(101, False, dtype=np.float32), sine_lc(11, False, dtype=np.float32)],
+    ],
 )
-@pytest.mark.parametrize("norm", [[], ["lgdt"], ["max"], ["lgdt", "max"]])
+@pytest.mark.parametrize("norm", [[], ["dt"], ["max"], ["dt", "max"]])
 def test_dmdt_points_many(lcs, norm):
-    dmdt = DmDt(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=norm)
+    dmdt = DmDt.from_borders(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=norm)
 
     desired = [dmdt.points(*lc) for lc in lcs]
     actual = dmdt.points_many(lcs)
@@ -103,11 +172,19 @@ def test_dmdt_points_many(lcs, norm):
     assert_array_equal(actual, desired)
 
 
-@pytest.mark.parametrize("lc", [sine_lc(101), random_lc(101)])
-@pytest.mark.parametrize("norm", [[], ["lgdt"], ["max"], ["lgdt", "max"]])
+@pytest.mark.parametrize("lc", [sine_lc(101), random_lc(101), sine_lc(101, dtype=np.float32)])
+@pytest.mark.parametrize("norm", [[], ["dt"], ["max"], ["dt", "max"]])
 @pytest.mark.parametrize("approx_erf", [True, False])
 def test_dmdt_gausses_many_one(lc, norm, approx_erf):
-    dmdt = DmDt(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=norm, approx_erf=approx_erf)
+    dmdt = DmDt.from_borders(
+        min_lgdt=-1,
+        max_lgdt=1,
+        max_abs_dm=2,
+        lgdt_size=32,
+        dm_size=32,
+        norm=norm,
+        approx_erf=approx_erf,
+    )
 
     desired = dmdt.gausses(*lc)
     assert np.any(desired != 0)
@@ -117,13 +194,93 @@ def test_dmdt_gausses_many_one(lc, norm, approx_erf):
     assert_array_equal(actual[0], desired)
 
 
-@pytest.mark.parametrize("lcs", [[sine_lc(101), sine_lc(11)], [random_lc(101), random_lc(101), random_lc(11)]])
-@pytest.mark.parametrize("norm", [[], ["lgdt"], ["max"], ["lgdt", "max"]])
+@pytest.mark.parametrize(
+    "lcs",
+    [
+        [sine_lc(101), sine_lc(11)],
+        [random_lc(101), random_lc(101), random_lc(11)],
+        [sine_lc(101, dtype=np.float32), sine_lc(11, dtype=np.float32)],
+    ],
+)
+@pytest.mark.parametrize("norm", [[], ["dt"], ["max"], ["dt", "max"]])
 @pytest.mark.parametrize("approx_erf", [True, False])
 def test_dmdt_gausses_many(lcs, norm, approx_erf):
-    dmdt = DmDt(min_lgdt=-1, max_lgdt=1, max_abs_dm=2, lgdt_size=32, dm_size=32, norm=norm, approx_erf=approx_erf)
+    dmdt = DmDt.from_borders(
+        min_lgdt=-1,
+        max_lgdt=1,
+        max_abs_dm=2,
+        lgdt_size=32,
+        dm_size=32,
+        norm=norm,
+        approx_erf=approx_erf,
+    )
 
     desired = [dmdt.gausses(*lc) for lc in lcs]
     actual = dmdt.gausses_many(lcs)
 
     assert_array_equal(actual, desired)
+
+
+@pytest.mark.parametrize("t_dtype,m_dtype", product(*[[np.float32, np.float64]] * 2))
+def test_dmdt_points_dtype(t_dtype, m_dtype):
+    t = np.linspace(0, 1, 11, dtype=t_dtype)
+    m = np.asarray(t, dtype=m_dtype)
+    dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=1, max_abs_dm=1, lgdt_size=2, dm_size=2, norm=[])
+    if t_dtype is m_dtype:
+        context = nullcontext()
+    else:
+        context = pytest.raises(TypeError)
+    with context:
+        dmdt.points(t, m)
+
+
+@pytest.mark.parametrize("t_dtype,m_dtype,sigma_dtype", product(*[[np.float32, np.float64]] * 3))
+def test_dmdt_gausses_dtype(t_dtype, m_dtype, sigma_dtype):
+    t = np.linspace(1, 2, 11, dtype=t_dtype)
+    m = np.asarray(t, dtype=m_dtype)
+    sigma = np.asarray(t, dtype=sigma_dtype)
+    dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=1, max_abs_dm=1, lgdt_size=2, dm_size=2, norm=[])
+    if t_dtype is m_dtype is sigma_dtype:
+        context = nullcontext()
+    else:
+        context = pytest.raises(TypeError)
+    with context:
+        dmdt.gausses(t, m, sigma)
+
+
+@pytest.mark.parametrize("t1_dtype,m1_dtype,t2_dtype,m2_dtype", product(*[[np.float32, np.float64]] * 4))
+def test_dmdt_points_many_dtype(t1_dtype, m1_dtype, t2_dtype, m2_dtype):
+    t1 = np.linspace(1, 2, 11, dtype=t1_dtype)
+    m1 = np.asarray(t1, dtype=m1_dtype)
+    t2 = np.asarray(t1, dtype=t2_dtype)
+    m2 = np.asarray(t1, dtype=m2_dtype)
+    lcs = [(t1, m1), (t2, m2)]
+    dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=1, max_abs_dm=1, lgdt_size=2, dm_size=2, norm=[])
+    if t1_dtype is m1_dtype is t2_dtype is m2_dtype:
+        context = nullcontext()
+    else:
+        context = pytest.raises(TypeError)
+    with context:
+        dmdt.points_many(lcs)
+        dmdt.points_batches(lcs)
+
+
+@pytest.mark.parametrize(
+    "t1_dtype,m1_dtype,sigma1_dtype,t2_dtype,m2_dtype,sigma2_dtype", product(*[[np.float32, np.float64]] * 6)
+)
+def test_dmdt_gausses_many_dtype(t1_dtype, m1_dtype, sigma1_dtype, t2_dtype, m2_dtype, sigma2_dtype):
+    t1 = np.linspace(1, 2, 11, dtype=t1_dtype)
+    m1 = np.asarray(t1, dtype=m1_dtype)
+    sigma1 = np.asarray(t1, dtype=sigma1_dtype)
+    t2 = np.asarray(t1, dtype=t2_dtype)
+    m2 = np.asarray(t1, dtype=m2_dtype)
+    sigma2 = np.asarray(t1, dtype=sigma2_dtype)
+    lcs = [(t1, m1, sigma1), (t2, m2, sigma2)]
+    dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=1, max_abs_dm=1, lgdt_size=2, dm_size=2, norm=[])
+    if t1_dtype is m1_dtype is sigma1_dtype is t2_dtype is m2_dtype is sigma2_dtype:
+        context = nullcontext()
+    else:
+        context = pytest.raises(TypeError)
+    with context:
+        dmdt.gausses_many(lcs)
+        dmdt.gausses_batches(lcs)


### PR DESCRIPTION
Initial support of Rust features in Python `Extractor`. It should make pure Rust feature list extraction faster.

I reimplemented Python's `BaseMetaFeature` and `Extractor`:
- `Extractor.__new__` returns Rust `Extractor` object if all features are Rust features, and returns `_PyExtractor` otherwise
- `_PyExtractor` doesn't inherit `BaseMetaFeature`, but
- `BaseMetaFeature` encapsulates `Extractor` to evaluate features on a transformed light curve

We still need some optimisations for the case of mixed Python-Rust feature lists

Also I merged current `master` here

This resolves #62, but do nothing with #72.