### PR TITLE
Redefine VillarFit parameters

### DIFF
--- a/light-curve-feature/CHANGELOG.md
+++ b/light-curve-feature/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rust edition 2021
 - Minimum rust version is 1.56
+- `VillarFit` now uses different parameter set to fix issue with non-physical negative flux fits, relative plateau amplitude `nu` replaces plateau slope `beta`. It is a breaking change
+- `VillarFit` name and description for `t_0` parameter are changed replacing "peak" to "reference", because this time moment does not correspond to the light-curve peak
+>>>>>>> 74239b4 (Redefine VillarFit parameters)
 
 ### Deprecated
 

--- a/light-curve-feature/CHANGELOG.md
+++ b/light-curve-feature/CHANGELOG.md
@@ -16,8 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rust edition 2021
 - Minimum rust version is 1.56
 - `VillarFit` now uses different parameter set to fix issue with non-physical negative flux fits, relative plateau amplitude `nu` replaces plateau slope `beta`. It is a breaking change
-- `VillarFit` name and description for `t_0` parameter are changed replacing "peak" to "reference", because this time moment does not correspond to the light-curve peak
->>>>>>> 74239b4 (Redefine VillarFit parameters)
+- `BazinFit` and `VillarFit` name and description for `t_0` parameter are changed replacing "peak" to "reference", because this time moment does not correspond to the light-curve peak
 
 ### Deprecated
 

--- a/light-curve-feature/src/features/bazin_fit.rs
+++ b/light-curve-feature/src/features/bazin_fit.rs
@@ -163,7 +163,7 @@ where
             bound[1].0 = norm_data.m_to_norm(bound[1].0);
             bound[1].1 = norm_data.m_to_norm(bound[1].1);
 
-            // peak time
+            // reference time
             x0[2] = norm_data.t_to_norm(x0[2]);
             bound[2].0 = norm_data.t_to_norm(bound[2].0);
             bound[2].1 = norm_data.t_to_norm(bound[2].1);
@@ -195,7 +195,7 @@ where
             let mut result = vec![0.0; 6];
             result[0] = norm_data.m_to_orig_scale(x.a()); // amplitude
             result[1] = norm_data.m_to_orig(x.b()); // offset
-            result[2] = norm_data.t_to_orig(x.t0()); // peak time
+            result[2] = norm_data.t_to_orig(x.t0()); // reference time
             result[3] = norm_data.t_to_orig_scale(x.tau_rise()); // rise time
             result[4] = norm_data.t_to_orig_scale(x.tau_fall()); // fall time
             result[5] = reduced_chi2;
@@ -216,7 +216,7 @@ where
         vec![
             "bazin_fit_amplitude",
             "bazin_fit_baseline",
-            "bazin_fit_peak_time",
+            "bazin_fit_reference_time",
             "bazin_fit_rise_time",
             "bazin_fit_fall_time",
             "bazin_fit_reduced_chi2",
@@ -227,7 +227,7 @@ where
         vec![
             "half amplitude of the Bazin function (A)",
             "baseline of the Bazin function (B)",
-            "peak time of the Bazin fit (t0)",
+            "reference time of the Bazin fit (t0)",
             "rise time of the Bazin function (tau_rise)",
             "fall time of the Bazin function (tau_fall)",
             "Bazin fit quality (reduced chi2)",

--- a/light-curve-feature/src/nl_fit/data.rs
+++ b/light-curve-feature/src/nl_fit/data.rs
@@ -91,14 +91,6 @@ where
         m_norm * self.m_std
     }
 
-    pub fn slope_to_orig(&self, slope_norm: T) -> T {
-        if self.t_std.is_zero() || self.m_std.is_zero() {
-            slope_norm
-        } else {
-            slope_norm * self.m_std / self.t_std
-        }
-    }
-
     #[allow(dead_code)]
     pub fn inv_err_to_orig(&self, inv_err_norm: T) -> T {
         inv_err_norm * self.inv_err_scale
@@ -139,13 +131,5 @@ where
     #[allow(dead_code)]
     pub fn inv_err_to_norm(&self, inv_err_orig: T) -> T {
         inv_err_orig / self.inv_err_scale
-    }
-
-    pub fn slope_to_norm(&self, slope_orig: T) -> T {
-        if self.t_std.is_zero() || self.m_std.is_zero() {
-            slope_orig
-        } else {
-            slope_orig * self.t_std / self.m_std
-        }
     }
 }

--- a/light-curve-feature/src/nl_fit/mod.rs
+++ b/light-curve-feature/src/nl_fit/mod.rs
@@ -12,17 +12,30 @@ pub mod mcmc;
 pub use mcmc::McmcCurveFit;
 
 #[cfg(test)]
-pub trait HyperdualFloat: hyperdual::Float {}
+pub trait HyperdualFloat: hyperdual::Float {
+    fn two() -> Self;
+}
 #[cfg(test)]
-impl<T> HyperdualFloat for T where T: hyperdual::Float {}
+impl<T> HyperdualFloat for T
+where
+    T: hyperdual::Float,
+{
+    #[inline]
+    fn two() -> Self {
+        Self::from(2.0).unwrap()
+    }
+}
 #[cfg(not(test))]
 pub trait HyperdualFloat: crate::Float {}
 #[cfg(not(test))]
 impl<T> HyperdualFloat for T where T: crate::Float {}
 
 pub trait F64LikeFloat:
-    HyperdualFloat + std::ops::AddAssign<Self> + std::ops::MulAssign<Self>
+    HyperdualFloat + std::ops::AddAssign<Self> + std::ops::MulAssign<Self> + Sized
 {
+    fn logistic(x: Self) -> Self {
+        (Self::one() + Self::exp(-x)).recip()
+    }
 }
 
 impl<T> F64LikeFloat for T where


### PR DESCRIPTION
There were an issue with VillarFit leading to non-physical fits,
when (A + beta * gamma) < 0. This fixes this issue replacing
beta parameter with nu: nu = -beta * gamma / A and limiting it
between 0 and 1

Related to #130