### PR TITLE
enum_dispatch for LnPriorTrait and LnPrior

### DIFF
--- a/light-curve-feature/CHANGELOG.md
+++ b/light-curve-feature/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-—
+- Use `enum_dispatch` crate to implement `LnPriorTrait` for `LnPrior`
 
 ### Deprecated
 

--- a/light-curve-feature/Cargo.toml
+++ b/light-curve-feature/Cargo.toml
@@ -27,7 +27,7 @@ conv = "^0.3.3"
 dyn-clonable = "^0.9.0"
 emcee = "^0.3.0"
 emcee_rand = { version = "^0.3.15", package = "rand" }
-enum_dispatch = "^0.3.7"
+enum_dispatch = { git = "https://gitlab.com/antonok/enum_dispatch.git", rev = "b88e87870b80aab51ff65da194a16ce514387060" }
 fftw = { version = "0.7.0", default-features = false }
 GSL = { version = "~6.0.0", default-features = false, optional = true }
 itertools = "^0.10.0"


### PR DESCRIPTION
We wait until [`enum_dispatch`](https://lib.rs/enum_dispatch) version with [this MR](https://gitlab.com/antonok/enum_dispatch/-/merge_requests/25) merged is released